### PR TITLE
Stick version for spid-saml-check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
 
   # uncomment if needed
   spid-saml-check:
-    image: italia/spid-saml-check
+    image: italia/spid-saml-check:v.1.8.1
     ports:
       - "8080:8080"
     networks:


### PR DESCRIPTION
spid-saml-check latest version has a bug as of: https://github.com/italia/spid-saml-check/issues/213
downgrade to `v1.8.1`  to temporary fix the problem.