### PR TITLE
fix typo in idps list

### DIFF
--- a/example/static/spid/spid-idps.js
+++ b/example/static/spid/spid-idps.js
@@ -16,7 +16,7 @@ const idps = [
   {"entityName": "Poste ID", "entityID": "https://posteid.poste.it", "logo": "spid/spid-idp-posteid.svg"},
   {"entityName": "Sielte ID", "entityID": "https://identity.sieltecloud.it", "logo": "spid/spid-idp-sielteid.svg"},
   {"entityName": "SPIDItalia Register.it", "entityID": "https://spid.register.it", "logo": "spid/spid-idp-spiditalia.svg"},
-  {"entityName": "Tim ID", "entityIDD": "https://login.id.tim.it/affwebservices/public/saml2sso", "logo": "spid/spid-idp-timid.svg"}
+  {"entityName": "Tim ID", "entityID": "https://login.id.tim.it/affwebservices/public/saml2sso", "logo": "spid/spid-idp-timid.svg"}
 ].sort(() => Math.random() - 0.5)
 
 // ** Values **


### PR DESCRIPTION
Salve. Ho notato un typo nel nome di una key nel javascript usato nella pagina disco.html che non permette al botton TIM di funzionare correttamente.