### PR TITLE
custom settings for wordpress test demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ example/private/*
 *pyFF_example/entities
 example_sp/djangosaml2_sp/sqlite3.db
 project/*
+
+my_docker_volumes
+my_custom_configurations

--- a/compose-Satosa-Saml2Spid/.env
+++ b/compose-Satosa-Saml2Spid/.env
@@ -1,3 +1,3 @@
 MONGO_DBUSER=satosa
 MONGO_DBPASSWORD=thatpassword
-HOSTNAME=localhost
+HOSTNAME=10.0.2.15

--- a/compose-Satosa-Saml2Spid/docker-compose.yml
+++ b/compose-Satosa-Saml2Spid/docker-compose.yml
@@ -77,9 +77,11 @@ services:
       - "9999:9999"
     volumes:
        - /usr/share/zoneinfo/Europe/Rome:/etc/localtime:ro
-       - satosa_metadata:/satosa_proxy/metadata
+       - ../my_docker_volumes/metadata:/satosa_proxy/metadata
        - satosa_static:/satosa_proxy/static
        - satosa_certs:/satosa_proxy/pki
+       - ../my_custom_configurations/target_based_routing.yaml:/satosa_proxy/plugins/microservices/target_based_routing.yaml
+       - ../my_custom_configurations/spid-idps.js:/satosa_proxy/static/spid/spid-idps.js
 
   satosa-nginx:
     image: nginx:alpine
@@ -94,7 +96,7 @@ services:
       - ./nginx/50x.html:/usr/share/nginx/html/50x.html:ro
       - ./nginx/404.html:/usr/share/nginx/html/404.html:ro
       - ./nginx/403.html:/usr/share/nginx/html/403.html:ro
-      - nginx_certs:/etc/nginx/certs:ro
+      - ../my_docker_volumes/nginx/certs:/etc/nginx/certs:ro
       - satosa_static:/var/www/html
 
 volumes:


### PR DESCRIPTION
The following changes have been made  to adapt the SaToSa container instance for our test case with spid-saml-check and Wordpress Onelogin plugin.

The docker-compose have now 2 new volumes:

- my_docker_volumes:
    - Contains the metadata and nginx folder and are used in substitution of satosa-saml2spid_metadata and  satosa-saml2spid_certs
        - We got some problems writing/reading inside the satosa-saml2spid_metadata e satosa-saml2spid_certs volumes so we have created this new folder to achieve the tests
- my_custom_configurations: used to add new target_based_routing.yaml mappings and spid-idps.js buttons.

 

To make SaToSa works with our IP machine(or docker network id) we have changed locally the HOSTNAME environment variable inside the .env file