### PR TITLE
fix: update `pyeudiw` version post-release

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ jinja2
 
 # Wallet RP
 # pyeudiw[satosa,federation]
-git+https://github.com/italia/eudi-wallet-it-python@dev
+pyeudiw
 
 Pillow>=10.0.0,<10.1
 device_detector>=5.0,<6


### PR DESCRIPTION
Revert `pyeudiw` installation from PyPI.

Changed temporary to GitHub dev branch as source for #107 