### PR TITLE
Update base image

### DIFF
--- a/Docker-compose/docker-compose.yml
+++ b/Docker-compose/docker-compose.yml
@@ -118,11 +118,11 @@ services:
     networks:
       - satosa-saml2spid
     healthcheck:
-      test: curl --fail http://localhost/SAML2IDP/metadata || exit 1
-      interval: 2s
+      test: wget -O - https://satosa-nginx/Saml2IDP/metadata --no-check-certificate || exit 1
+      interval: 30s
       retries: 10
-      start_period: 10s
-      timeout: 10s
+      start_period: 30s
+      timeout: 30s
 
   satosa-nginx:
     image: nginx:alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19.1
 
 # Metadata params
 ARG BUILD_DATE
@@ -32,10 +32,12 @@ COPY requirements.txt /
 
 ENV BASEDIR="/satosa_proxy"
 
-RUN apk add --update xmlsec libffi-dev openssl-dev python3 py3-pip python3-dev procps git openssl build-base gcc wget bash jq yq \
- && pip3 install --upgrade pip setuptools --root-user-action=ignore \
- && pip3 install -r requirements.txt --ignore-installed --root-user-action=ignore \
- && mkdir $BASEDIR
+RUN apk add --update xmlsec libffi-dev openssl-dev python3 py3-pip python3-dev procps git openssl build-base gcc wget bash jq yq
+
+ENV BASEDIR="/satosa_proxy"
+
+RUN python3 -m venv .venv && . .venv/bin/activate && pip3 install --upgrade pip setuptools \ 
+      && pip3 install -r requirements.txt --ignore-installed --root-user-action=ignore && mkdir $BASEDIR
 
 RUN pip list
 

--- a/example/entrypoint.sh
+++ b/example/entrypoint.sh
@@ -8,4 +8,5 @@ if [[ $GET_IDEM_MDQ_KEY == true ]]; then
   echo "Downloaded IDEM MDQ key"
 fi
 
-uwsgi --ini /satosa_proxy/uwsgi_setup/uwsgi/uwsgi.ini.docker
+wsgi_file=/.venv/lib/$(python -c 'import sys; print(f"python{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/satosa/wsgi.py
+uwsgi --ini /satosa_proxy/uwsgi_setup/uwsgi/uwsgi.ini.docker --wsgi-file $wsgi_file

--- a/example/entrypoint.sh
+++ b/example/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+. /.venv/bin/activate
 
 # get IDEM MDQ key
 if [[ $GET_IDEM_MDQ_KEY == true ]]; then

--- a/example/uwsgi_setup/uwsgi/uwsgi.ini.docker
+++ b/example/uwsgi_setup/uwsgi/uwsgi.ini.docker
@@ -14,7 +14,6 @@ processes   = 8
 # sets max connections to
 listen = 2048
 
-wsgi-file = /.venv/lib/python3.11/site-packages/satosa/wsgi.py
 callable = app
 
 log-master-bufsize = 128000

--- a/example/uwsgi_setup/uwsgi/uwsgi.ini.docker
+++ b/example/uwsgi_setup/uwsgi/uwsgi.ini.docker
@@ -14,7 +14,7 @@ processes   = 8
 # sets max connections to
 listen = 2048
 
-wsgi-file   = /usr/lib/python3.11/site-packages/satosa/wsgi.py
+wsgi-file = /.venv/lib/python3.11/site-packages/satosa/wsgi.py
 callable = app
 
 log-master-bufsize = 128000

--- a/example_sp/django.Dockerfile
+++ b/example_sp/django.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.19.1
  
 RUN apk update
 RUN apk add --update --no-cache tzdata
@@ -11,9 +11,7 @@ COPY example_sp/entrypoint.sh /
 
 WORKDIR /djangosaml2_sp
 
-RUN apk add --update xmlsec-dev libffi-dev openssl-dev python3 py3-pip python3-dev procps git openssl build-base gcc wget bash jq yq \
-&& pip3 install --upgrade pip setuptools --root-user-action=ignore
+RUN apk add --update xmlsec-dev libffi-dev openssl-dev python3 py3-pip python3-dev procps git openssl build-base gcc wget bash jq yq 
 
-RUN pip list
-
-RUN pip3 install -r ../requirements.txt --ignore-installed --root-user-action=ignore
+RUN python3 -m venv .venv && . .venv/bin/activate && pip3 install --upgrade pip setuptools \ 
+    && pip3 install -r ../requirements.txt --ignore-installed --root-user-action=ignore

--- a/example_sp/entrypoint.sh
+++ b/example_sp/entrypoint.sh
@@ -1,2 +1,3 @@
+. /djangosaml2_sp/.venv/bin/activate
 python -B manage.py migrate
 python -B manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
Clean PR to replace #117 

- Update Satosa base image from `alpine:3.18` to `alpine:3.19.1`.
- Update Django example base image from `alpine:3.18` to `alpine:3.19.1`.

Both images now install python packages into a dedicated virtual environment, solving the error raised by Alpine:

> The system-wide python installation should be maintained using the system
>     package manager (apk) only.


Fixes #110
Fixes #111
