### PR TITLE
fix: SAML2 Issuer format SPID test 30, issuer MAY be omitted

### DIFF
--- a/example/backends/ciesaml2.py
+++ b/example/backends/ciesaml2.py
@@ -472,7 +472,6 @@ class CieSAMLBackend(SAMLBackend):
                 **{"message": _msg, "troubleshoot": _TROUBLESHOOT_MSG}
             )
 
-        list(context.state.keys())[1]
         # deprecated
         # if not context.state.get('Saml2IDP'):
         # _msg = "context.state['Saml2IDP'] KeyError"
@@ -496,6 +495,7 @@ class CieSAMLBackend(SAMLBackend):
             authn_context_class_ref=authn_context_classref,
             return_addrs=authn_response.return_addrs,
             allowed_acrs=self.config["spid_allowed_acrs"],
+            cie_mode = True
         )
         try:
             validator.run()

--- a/example/backends/spidsaml2_validator.py
+++ b/example/backends/spidsaml2_validator.py
@@ -78,7 +78,7 @@ class Saml2ResponseValidator(object):
         # 30
         # check that this issuer is in the metadata...
         # L'attributo Format di Issuer della Response deve essere omesso o assumere valore urn:oasis:names:tc:SAML:2.0:nameid-format:entity. In questo test il valore è diverso. Risultato atteso: KO
-        if hasattr(self.response.issuer, "format"):
+        if hasattr(self.response.issuer, "format") and self.response.issuer.format:
             if (
                 self.response.issuer.format
                 != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity"

--- a/example/backends/spidsaml2_validator.py
+++ b/example/backends/spidsaml2_validator.py
@@ -34,6 +34,7 @@ class Saml2ResponseValidator(object):
         authn_context_class_ref="https://www.spid.gov.it/SpidL2",
         return_addrs=[],
         allowed_acrs=[],
+        cie_mode = False
     ):
 
         self.response = samlp.response_from_string(authn_response)
@@ -45,6 +46,7 @@ class Saml2ResponseValidator(object):
         self.return_addrs = return_addrs
         self.issuer = issuer
         self.allowed_acrs = allowed_acrs
+        self.cie_mode = cie_mode
 
     # handled adding authn req arguments in the session state (cookie)
     def validate_in_response_to(self):
@@ -88,13 +90,14 @@ class Saml2ResponseValidator(object):
                     '!= "urn:oasis:names:tc:SAML:2.0:nameid-format:entity"'
                 )
 
-        msg = "Issuer format is not valid: {}. {}"
-        # 70, 71
-        assiss = self.response.assertion[0].issuer
-        if not hasattr(assiss, "format") or not getattr(assiss, "format", None):
-            raise SPIDValidatorException(
-                msg.format(self.response.issuer.format, _ERROR_TROUBLESHOOT)
-            )
+        if not self.cie_mode:
+            msg = "Issuer format is not valid: {}. {}"
+            # 70, 71
+            assiss = self.response.assertion[0].issuer
+            if not hasattr(assiss, "format") or not getattr(assiss, "format", None):
+                raise SPIDValidatorException(
+                    msg.format(self.response.issuer.format, _ERROR_TROUBLESHOOT)
+                )
 
         # 72
         for i in self.response.assertion:

--- a/example/backends/spidsaml2_validator.py
+++ b/example/backends/spidsaml2_validator.py
@@ -99,13 +99,13 @@ class Saml2ResponseValidator(object):
                     msg.format(self.response.issuer.format, _ERROR_TROUBLESHOOT)
                 )
 
-        # 72
-        for i in self.response.assertion:
-            if i.issuer.format != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity":
-                raise SPIDValidatorException(
-                    msg.format(self.response.issuer.format,
-                               _ERROR_TROUBLESHOOT)
-                )
+            # 72
+            for i in self.response.assertion:
+                if i.issuer.format != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity":
+                    raise SPIDValidatorException(
+                        msg.format(self.response.issuer.format,
+                                   _ERROR_TROUBLESHOOT)
+                    )
 
     def validate_assertion_version(self):
         """spid saml check 35"""

--- a/example/backends/spidsaml2_validator.py
+++ b/example/backends/spidsaml2_validator.py
@@ -78,7 +78,7 @@ class Saml2ResponseValidator(object):
         # 30
         # check that this issuer is in the metadata...
         # L'attributo Format di Issuer della Response deve essere omesso o assumere valore urn:oasis:names:tc:SAML:2.0:nameid-format:entity. In questo test il valore è diverso. Risultato atteso: KO
-        if hasattr(self.response.issuer.format):
+        if hasattr(self.response.issuer, "format"):
             if (
                 self.response.issuer.format
                 != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity"

--- a/example/backends/spidsaml2_validator.py
+++ b/example/backends/spidsaml2_validator.py
@@ -77,7 +77,8 @@ class Saml2ResponseValidator(object):
 
         # 30
         # check that this issuer is in the metadata...
-        if self.response.issuer.format:
+        # L'attributo Format di Issuer della Response deve essere omesso o assumere valore urn:oasis:names:tc:SAML:2.0:nameid-format:entity. In questo test il valore è diverso. Risultato atteso: KO
+        if hasattr(self.response.issuer.format):
             if (
                 self.response.issuer.format
                 != "urn:oasis:names:tc:SAML:2.0:nameid-format:entity"


### PR DESCRIPTION
It turns out that CIE SAML2 Response fails with SPID test number 30

at the same time, according to SAML2 Core and SPID tests, the response.issuer.format MUST be omitted or if present MUST be equal to ... and CIE SAML2 IDP returns a Saml2 Respons ewithout self.response.issuer.format

This PR fixes the Spid Validator