### PR TITLE
fix: support for attach though wsgi

### DIFF
--- a/example/entrypoint.sh
+++ b/example/entrypoint.sh
@@ -9,4 +9,9 @@ if [[ $GET_IDEM_MDQ_KEY == true ]]; then
 fi
 
 wsgi_file=/.venv/lib/$(python -c 'import sys; print(f"python{sys.version_info.major}.{sys.version_info.minor}")')/site-packages/satosa/wsgi.py
-uwsgi --ini /satosa_proxy/uwsgi_setup/uwsgi/uwsgi.ini.docker --wsgi-file $wsgi_file
+wgsi_args="--ini /satosa_proxy/uwsgi_setup/uwsgi/uwsgi.ini.docker --wsgi-file $wsgi_file"
+if [[ $SATOSA_DEBUG == true ]]; then
+  wgsi_args="${wsgi_args} --honour-stdin"
+fi
+
+uwsgi $wsgi_args


### PR DESCRIPTION
Pull request https://github.com/italia/Satosa-Saml2Spid/pull/143 introduced the docker configuration required to attach a Python debugger in the container of `satosa-saml2spid`. This configuration is bounded to the environment variable `SATOSA_DEBUG`.
This fix further enhances this proposal, by letting the enchament work with WSGI