### PR TITLE
fix: spid-saml-check tls check demo

### DIFF
--- a/Docker-compose/README.md
+++ b/Docker-compose/README.md
@@ -15,12 +15,12 @@
 In order to execute the run script you need:
 
 * jq
-* docker-compose
+* docker version 3
 
 Installation example in Ubuntu:
 
 ```
-sudo apt install jq docker-compose
+sudo apt install jq
 ```
 
 For docker-compose you can also [see here](https://docs.docker.com/compose/install/other/).

--- a/Docker-compose/docker-compose.yml
+++ b/Docker-compose/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   satosa-mongo:
     image: mongo
@@ -146,6 +145,8 @@ services:
   spid-samlcheck:
     image: italia/spid-saml-check
     container_name: spid-samlcheck
+    environment:
+      - NODE_TLS_REJECT_UNAUTHORIZED=0
     ports:
       - "8443:8443"
     networks:

--- a/Docker-compose/docker-compose.yml
+++ b/Docker-compose/docker-compose.yml
@@ -146,7 +146,7 @@ services:
     image: italia/spid-saml-check
     container_name: spid-samlcheck
     environment:
-      - NODE_TLS_REJECT_UNAUTHORIZED=0
+      - NODE_TLS_REJECT_UNAUTHORIZED=${NODE_TLS_REJECT_UNAUTHORIZED:-0}
     ports:
       - "8443:8443"
     networks:

--- a/Docker-compose/rm-persistent-volumes.sh
+++ b/Docker-compose/rm-persistent-volumes.sh
@@ -23,7 +23,7 @@ echo -e "\n"
 echo -e "Inizio le procedure per fare il down della composizione e poi CANCELLARE i volumi persistenti! \n"
 
 echo -e "Fermo la composizione! \n"
-docker-compose -f docker-compose.yml down -v;
+docker compose -f docker-compose.yml down -v;
 
 echo -e "\n"
 


### PR DESCRIPTION
This PR fixes:

- spid-saml-check SP metadata download, TLS validation for demo purpose
- docker-compose version parameter due to its deprecation (warning removed)
- several pending deprecated dependencies in scripts and documentation