### PR TITLE
chore: remove redundant address mapping

### DIFF
--- a/example/internal_attributes.yaml
+++ b/example/internal_attributes.yaml
@@ -97,8 +97,6 @@ attributes:
     saml: [countyOfBirth]
   dateOfBirth:
     saml: [dateOfBirth]
-  address:
-    saml: [address]
   mobilePhone:
     saml: [mobilePhone]
   expirationDate:


### PR DESCRIPTION
`address` appears already [here](https://github.com/italia/Satosa-Saml2Spid/blob/9071a730676431f5129bed5e81a6a4863669897b/example/internal_attributes.yaml#L2).