### PR TITLE
Docker demo env not overwritten

### DIFF
--- a/Docker-compose/run-docker-compose.sh
+++ b/Docker-compose/run-docker-compose.sh
@@ -49,7 +49,7 @@ function initialize_satosa {
   mkdir -p ./certbot/live/localhost
   mkdir -p ./spid_cie_oidc_django
 
-  init_files ./.env ".env" "cp env.example .env"
+  if [ -f ./.env ] && [ "$SATOSA_FORCE_ENV" != "true" ]; then echo ".env file is already initialized" ; else cp env.example .env ; fi
   init_files ./iam-proxy-italia-project/proxy_conf.yaml "iam-proxy-italia" "cp -R ../iam-proxy-italia-project ./"
   init_files ./djangosaml2_sp/run.sh "djangosaml2_sp" "cp -R ../iam-proxy-italia-project-demo-examples/djangosaml2_sp ./"
   init_files ./nginx/html/static/disco.html "static pages" "cp -R ../iam-proxy-italia-project/static ./nginx/html"


### PR DESCRIPTION
This pull request updates the environment file initialization logic in the `initialize_satosa` function to prevent overwriting an existing `.env` file unless explicitly requested. This improves safety and flexibility during setup.

Environment file initialization:

* The script now checks if a `.env` file already exists and only overwrites it if the `SATOSA_FORCE_ENV` environment variable is set to `"true"`, preventing accidental loss of local configuration.

this PR resolves https://github.com/italia/iam-proxy-italia/issues/213