### PR TITLE
feat: allow custom Mongo connection parameters in CieOidcRp backend

### DIFF
--- a/iam-proxy-italia-project/backends/cieoidc/storage/impl/mongo_storage.py
+++ b/iam-proxy-italia-project/backends/cieoidc/storage/impl/mongo_storage.py
@@ -24,8 +24,7 @@ class MongoStorage(OidcStorage):
         self._db_name = conf.get("db_name")
         self._data_ttl = conf.get("data_ttl")
         self._url = url
-        self._username = (connection_params or {}).get("username")
-        self._password = (connection_params or {}).get("password")
+        self._connection_params = connection_params or {}
         self._auth_collection = conf.get("db_auth_collection")
         self.__client = None
 
@@ -37,7 +36,7 @@ class MongoStorage(OidcStorage):
 
     def connect(self) -> None:
         if self.__client is None:
-            self.__client = MongoClient(self._url, username=self._username, password=self._password)
+            self.__client = MongoClient(self._url, **self._connection_params)
 
     def close(self) -> None:
         if self.__client is not None:


### PR DESCRIPTION
Following the same pattern of [satosa-oidcop][1], we allow setting custom connection parameters in https://github.com/italia/iam-proxy-italia/blob/a907faca5a9766edb637d3e7e691ce5cd7161eb2/iam-proxy-italia-project/conf/backends/cieoidc_backend.yaml#L22

[1]: https://github.com/UniversitaDellaCalabria/SATOSA-oidcop/blob/821f4e42ed490d5e415c819ff40578ceb68d1d7e/satosa_oidcop/core/storage/mongo.py#L44